### PR TITLE
Add multi-core cpu benchmark

### DIFF
--- a/src/apiserver/apiserver.go
+++ b/src/apiserver/apiserver.go
@@ -102,7 +102,8 @@ func ApiServer() {
 	g.GET("/init", common.RestGetInit)
 	g.GET("/clean", common.RestGetClean)
 
-	g.GET("/cpu", common.RestGetCPU)
+	g.GET("/cpus", common.RestGetCPUS)
+	g.GET("/cpum", common.RestGetCPUM)
 	g.GET("/memR", common.RestGetMEMR)
 	g.GET("/memW", common.RestGetMEMW)
 	g.GET("/fioR", common.RestGetFIOR)

--- a/src/common/utility.go
+++ b/src/common/utility.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"os/exec"
+	"runtime"
 )
 
 
@@ -40,12 +41,13 @@ func SysLookPath(cmdStr string) (string, error) {
 	
 }
 
-// MCIS utilities
-
 func GenUuid() string {
 	return uuid.New().String()
 }
 
+func GetNumCPU() int {
+	return runtime.NumCPU()
+}
 
 
 func PrintJsonPretty(v interface{}) {

--- a/test/full_test.sh
+++ b/test/full_test.sh
@@ -3,7 +3,7 @@
 HOST=${1-"localhost"}
 CMD=${2-""}
 
-function full_test() {
+
 
 	if [ "${CMD}" == "install" ]
 		then
@@ -19,13 +19,9 @@ function full_test() {
 	curl -sX GET http://${HOST}:1324/milkyway/init | json_pp || return 1
 	echo "#-----------------------------"
 
-	curl -sX GET http://${HOST}:1324/milkyway/rtt -H 'Content-Type: application/json' -d '{ "host": "localhost"}' |json_pp || return 1
+	curl -sX GET http://${HOST}:1324/milkyway/cpus | json_pp || return 1
 	echo "#-----------------------------"
-
-	curl -sX GET http://${HOST}:1324/milkyway/mrtt -H 'Content-Type: application/json' -d '{ "multihost": [{"host":"localhost"},{"host":"localhost"}]}' |json_pp || return 1
-	echo "#-----------------------------"
-
-	curl -sX GET http://${HOST}:1324/milkyway/cpu | json_pp || return 1
+	curl -sX GET http://${HOST}:1324/milkyway/cpum | json_pp || return 1
 	echo "#-----------------------------"
 	curl -sX GET http://${HOST}:1324/milkyway/memR | json_pp || return 1
 	echo "#-----------------------------"
@@ -40,9 +36,13 @@ function full_test() {
 	curl -sX GET http://${HOST}:1324/milkyway/dbW | json_pp || return 1
 	echo "#-----------------------------"
 
+	curl -sX GET http://${HOST}:1324/milkyway/rtt -H 'Content-Type: application/json' -d '{ "host": "localhost"}' |json_pp || return 1
+	echo "#-----------------------------"
+	curl -sX GET http://${HOST}:1324/milkyway/mrtt -H 'Content-Type: application/json' -d '{ "multihost": [{"host":"localhost"},{"host":"localhost"}]}' |json_pp || return 1
+	echo "#-----------------------------"
+
 	curl -sX GET http://${HOST}:1324/milkyway/clean | json_pp || return 1
 	echo "#-----------------------------"
 
-}
+	
 
-full_test

--- a/test/multi_host_install_test.sh
+++ b/test/multi_host_install_test.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+for var in "$@"
+do
+    ./full_test.sh "$var" install &
+done
+
+

--- a/test/multi_host_test.sh
+++ b/test/multi_host_test.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+for var in "$@"
+do
+    ./full_test.sh "$var" &
+done
+
+


### PR DESCRIPTION
This PR add multi-core cpu benchmark function.

This function get the number of cores in a host, 
and utilizes it as the number of threads to calculate prime numbers.